### PR TITLE
Two small fixes

### DIFF
--- a/Product Manuals/Java Model Runner/index.md
+++ b/Product Manuals/Java Model Runner/index.md
@@ -141,4 +141,4 @@ If the Java model requires one or more JAR files, supply them together with any 
 
 ## Stream Encoding
 
-In v1.5, the Java runner only supports JSON encoding for input/output streams.
+Currently, the Java runner only supports JSON and CSV encoding for input/output streams.

--- a/Reference/FastScore CLI/index.md
+++ b/Reference/FastScore CLI/index.md
@@ -35,6 +35,7 @@ fastscore <command> <subcommand> ...
 * [fastscore sensor add/show/list/remove](#sensor-mgmt)
 * [fastscore sensor install/uninstall/inspect/points](#sensor-install)
 * [fastscore engine reset/inspect/pause/unpause](#engine-state)
+* [fastscore run](#run-simple)
 * [fastscore snapshot list/show/remove](#snapshot-mgmt)
 * [fastscore snapshot restore](#snapshot-restore)
 * [fastscore policy set/show](#policy)
@@ -43,7 +44,7 @@ fastscore <command> <subcommand> ...
 * [fastscore profile](#profile)
 * [fastscore pneumo](#pneumo)
 * [fastscore monitor](#monitor)
-* [fastscore run](#run-simple)
+* [URL-like stream descriptors] (#literal-streams)
 
 ## Getting help
 <a name="help"></a>


### PR DESCRIPTION
I made a couple of small fixes. George tells me that the Java runner now supports CSV as well as JSON encoding, so I made a change reflective of that. In the CLI docs, the link to 'fastscore run' was out of order and the section entitled "URL-like stream descriptors" was not linked to making it difficult to find. We should think about moving URL-like stream descriptors up to where the stream documentation is. I had no idea that section was there until my dog stepped on my keyboard and accidentally scrolled down to the bottom of the page.